### PR TITLE
allow showProgressIndicator to be optionally dismissed

### DIFF
--- a/lib/src/controllers/overlay_controller.mixin.dart
+++ b/lib/src/controllers/overlay_controller.mixin.dart
@@ -112,13 +112,17 @@ mixin OverlayController {
   Future<OverlayEntry> showProgressIndicator(
       {Widget Function(BuildContext? context)? builder,
       Color? backgroundColor,
-      Color? circularProgressIndicatorColor}) {
+      Color? circularProgressIndicatorColor,
+      bool allowDismiss = false}) {
     return showOverlay(
         builder: (_) => Stack(
               children: <Widget>[
                 ModalBarrier(
-                  dismissible: false,
+                  dismissible: allowDismiss,
                   color: backgroundColor ?? Colors.black45,
+                  onDismiss: () {
+                    if (allowDismiss) hideOverlay();
+                  },
                 ),
                 builder != null
                     ? builder(context)


### PR DESCRIPTION
-optionally allow the showProgressIndicator to be dismissed on screen tap if the allowDismiss parameter is passed. 
-default function remains, until dismiss is enabled by passing the allowDismiss parameter