### PR TITLE
feat: Add progressIndicatorBuilder

### DIFF
--- a/lib/src/controllers/one_context.dart
+++ b/lib/src/controllers/one_context.dart
@@ -21,6 +21,8 @@ class OneContext with NavigatorController, OverlayController, DialogController {
 
   set context(BuildContext? newContext) => _context = newContext;
 
+  Widget Function(BuildContext? context)? progressIndicatorBuilder;
+
   /// If you need reactive changes, do not use OneContext().mediaQuery
   /// Use `MediaQuery.of(context)` instead.
   MediaQueryData get mediaQuery => MediaQuery.of(context!);

--- a/lib/src/controllers/overlay_controller.mixin.dart
+++ b/lib/src/controllers/overlay_controller.mixin.dart
@@ -126,11 +126,13 @@ mixin OverlayController {
                 ),
                 builder != null
                     ? builder(context)
-                    : Center(
-                        child: CircularProgressIndicator(
-                        valueColor: AlwaysStoppedAnimation<Color>(
-                            circularProgressIndicatorColor ?? Colors.white),
-                      ))
+                    : OneContext().progressIndicatorBuilder != null
+                        ? OneContext().progressIndicatorBuilder!(context)
+                        : Center(
+                            child: CircularProgressIndicator(
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                                circularProgressIndicatorColor ?? Colors.white),
+                          ))
               ],
             ));
   }


### PR DESCRIPTION
```dart
// example/lib/main.dart

class MyApp extends StatelessWidget {
...
  @override
  Widget build(BuildContext context) {
...
        OneContext().progressIndicatorBuilder = (context) {
          return Center(
            child: CircularProgressIndicator(
              color: Colors.red,
            ),
          );
        };

```

https://github.com/user-attachments/assets/b6ff3145-c8ca-477e-b717-08b52c998951

Hello,

I would like to propose the addition of the OneContext().progressIndicatorBuilder feature.

This feature allows users to globally set the builder when calling showProgressIndicator.

I would appreciate your feedback!

Thank you.

